### PR TITLE
Fix typo in remove_dupes warning message

### DIFF
--- a/pandas_diff/pre_process.py
+++ b/pandas_diff/pre_process.py
@@ -42,7 +42,7 @@ def remove_dupes(compare_columns, df, name):
     duplicated_rows_in_df = df[df.duplicated(subset=compare_columns, keep=False)].shape[0]
     if duplicated_rows_in_df  :
         duplicated = str(df[df.duplicated(subset=compare_columns, keep=False)].to_dict(orient="records"))
-        message_warning = f"Found {duplicated_rows_in_df} duplicated rows in {name} dataframe: " + duplicated + ". Removing duplicates, except last occurrente."
+        message_warning = f"Found {duplicated_rows_in_df} duplicated rows in {name} dataframe: " + duplicated + ". Removing duplicates, except last occurrence."
         warnings.warn(message_warning)
         df = df.drop_duplicates(subset=compare_columns, keep="last")
     return df


### PR DESCRIPTION
Fixed a typo in the warning message in the `remove_dupes` function where 'occurrente' was incorrectly spelled instead of 'occurrence'.

This is a minor text fix that improves the clarity of the warning message shown to users when duplicate rows are detected and removed from the dataframe.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.